### PR TITLE
zaki/amp_dev_updates_iframe

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -73,6 +73,10 @@ p {
     margin-bottom: 30px;
 }
 
+.spinner {
+    margin: 0 auto;
+}
+
 hr {
     width: 120px;
     border-left: 0;

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@ layout: default
                 layout="fixed-height"
                 sandbox="allow-scripts allow-same-origin allow-forms"
                 src="https://www.binary.com/en/landing/signup-frame.html">
-                <p class = "center-text">
-                    <amp-img placeholder layout="fixed" height="67" width="104" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
-                </p>
-    </amp-iframe>
+                <amp-img placeholder layout="fixed" height="67" width="104" class="spinner" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
+  </amp-iframe>
 </div>

--- a/pages/amp/en/index.html
+++ b/pages/amp/en/index.html
@@ -10,8 +10,6 @@ language: en
                 layout="fixed-height"
                 sandbox="allow-scripts allow-same-origin allow-forms"
                 src="https://www.binary.com/en/landing/signup-frame.html">
-                <p class = "center-text">
-                    <amp-img placeholder layout="fixed" height="67" width="104" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
-                </p>
+                <amp-img placeholder layout="fixed" height="67" width="104" class="spinner" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
     </amp-iframe>
 </div>

--- a/pages/amp/id/index.html
+++ b/pages/amp/id/index.html
@@ -10,8 +10,6 @@ language: id
                 layout="fixed-height"
                 sandbox="allow-scripts allow-same-origin allow-forms"
                 src="https://www.binary.com/en/landing/signup-frame.html">
-                <p class = "center-text">
-                    <amp-img placeholder layout="fixed" height="67" width="104" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
-                </p>
+                <amp-img placeholder layout="fixed" height="67" width="104" class="spinner" src={{ "/assets/img/spinner.gif" | prepend: site.github.url | replace: 'http://', 'https://' }}></amp-img>
     </amp-iframe>
 </div>


### PR DESCRIPTION
Fixed issue with iframe not loading due to amp-img placeholder restriction. Applied centering directly to amp-img class for spinner.